### PR TITLE
Allowing nette/utils 2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	],
 	"require": {
 		"php": ">=7.1.0",
-		"nette/utils": "^3.1",
+		"nette/utils": "^3.0 || ^2.4",
 		"latte/latte": "^2.5",
 		"mpdf/mpdf": "^8.0"
 	},


### PR DESCRIPTION
Only usage of nette/utils I found was SmartObject which exist since nette/utils 2.4.0